### PR TITLE
Add `opensips_start` var to allow disabling startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the httpd module, you will have to add to the list `opensips-http-modules`. Defa
 (`[]`) - no other modules are installed.
 * `opensips_config` - specify a configuration template that is going to be
 used instead of the default opensips configuration file.
-* `run_opensips` - specify whether OpenSIPS should be started/restarted. Default value is `yes`.
+* `opensips_start` - specify whether OpenSIPS should be started/restarted. Default value is `yes`.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ the httpd module, you will have to add to the list `opensips-http-modules`. Defa
 (`[]`) - no other modules are installed.
 * `opensips_config` - specify a configuration template that is going to be
 used instead of the default opensips configuration file.
+* `run_opensips` - specify whether OpenSIPS should be started/restarted. Default value is `yes`.
 
 Example Playbook
 ----------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 # handlers file for opensips
 
-- name: opensips start
+- name: opensips enable
   service:
     name: opensips
     enabled: true
-    state: started
 
 - name: opensips restart
   service:
     name: opensips
     state: restarted
+    when: run_opensips | default(True)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,4 +10,4 @@
   service:
     name: opensips
     state: restarted
-    when: run_opensips | default(True)
+  when: run_opensips | default(True)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,4 +10,4 @@
   service:
     name: opensips
     state: restarted
-  when: run_opensips | default(True)
+  when: opensips_start | default(True)

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -29,7 +29,7 @@
     name: opensips
     state: present
   notify:
-    - opensips start
+    - opensips enable
     - opensips restart
   register: apt_install_result
   until: apt_install_result is success
@@ -42,7 +42,7 @@
     state: present
   when: opensips_modules is defined and opensips_modules | length
   notify:
-    - opensips start
+    - opensips enable
     - opensips restart
   register: apt_modules_install_result
   until: apt_modules_install_result is success

--- a/tasks/redhatdnf.yml
+++ b/tasks/redhatdnf.yml
@@ -44,7 +44,7 @@
     name: opensips
     state: present
   notify:
-    - opensips start
+    - opensips enable
     - opensips restart
   register: dnf_install_result
   until: dnf_install_result is success
@@ -57,7 +57,7 @@
     state: present
   when: opensips_modules is defined and opensips_modules | length
   notify:
-    - opensips start
+    - opensips enable
     - opensips restart
   register: dnf_modules_install_result
   until: dnf_modules_install_result is success

--- a/tasks/redhatyum.yml
+++ b/tasks/redhatyum.yml
@@ -44,7 +44,7 @@
     name: opensips
     state: present
   notify:
-    - opensips start
+    - opensips enable
     - opensips restart
   register: yum_install_result
   until: yum_install_result is success
@@ -57,7 +57,7 @@
     state: present
   when: opensips_modules is defined and opensips_modules | length
   notify:
-    - opensips start
+    - opensips enable
     - opensips restart
   register: yum_modules_install_result
   until: yum_modules_install_result is success


### PR DESCRIPTION
Example use case: when creating an AMI the EC2 node might not have access to the database and OpenSIPS startup will fail.

Seems like the "start" followed by "restart" is unnecessary, it seems like you can restart a service without having started it first.